### PR TITLE
Use 0 as invalid robotID

### DIFF
--- a/mitecom-handler.cpp
+++ b/mitecom-handler.cpp
@@ -23,7 +23,7 @@ MixedTeamMate MixedTeamParser::parseIncoming(const void* messageData, uint32_t m
 	assert(htonl(0x12345678) != 0x12345678);
 
 	MixedTeamMate mate;
-	mate.robotID = -1; // mark as invalid
+	mate.robotID = 0; // mark as invalid
 
 	const MixedTeamCommMessage *message = (const MixedTeamCommMessage*)messageData;
 

--- a/mitecom-main.cpp
+++ b/mitecom-main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char* argv[]) {
 		if (messageLength > 0) {
 			// message received, process it
 			MixedTeamMate teamMate = MixedTeamParser::parseIncoming(buffer, messageLength, teamID);
-			if (teamMate.robotID != robotID) {
+			if (teamMate.robotID && teamMate.robotID != robotID) {
 				process(teamMate);
 			}
 		} else {


### PR DESCRIPTION
robotID is unsigned, so using -1 there may be a bad idea