### PR TITLE
Proposal for adding more information to the mitecom (and small doc update)

### DIFF
--- a/doc/coordinates.txt
+++ b/doc/coordinates.txt
@@ -9,7 +9,11 @@ Relative Coordinate System
 
 The relative coordinate system is for local measurements of the robots. The
 coordinate center is the robot, with the x axis facing forward (based on the
-torso) and the y axis facing left. 
+torso) and the y axis facing left.
+The 0 value of the orientation is pointing to the opponent end of the field
+(right side in the image).
+The value increases counter clockwise.
+
 
 Examples (unit = mm):
 
@@ -28,14 +32,13 @@ y axis to the left.
 
       y
       ^       ______________________
-      |    M  |          |          |  O
-      |    Y  |_ -x, y   |   x, y  _|  P
-      |    G  | |        |        | |  P
- 0    +    O  | |       ( )       | |  G
-      |    A  |_|        |        |_|  O
-      |    L  |  -x,-y   |   x,-y   |  A
-      |       |__________|__________|  L
+      |    M  |          |          |  O             90°
+      |    Y  |_ -x, y   |   x, y  _|  P              ^
+      |    G  | |        |        | |  P              |
+ 0    +    O  | |       ( )       | |  G       180° <- -> 0°
+      |    A  |_|        |        |_|  O              |
+      |    L  |  -x,-y   |   x,-y   |  A              v
+      |       |__________|__________|  L             270°
       |
       +------------------+--------------> x
                          0
-

--- a/mitecom-data.h
+++ b/mitecom-data.h
@@ -94,16 +94,19 @@ typedef MixedTeamStateEnum MixedTeamState;
 
 /*------------------------------------------------------------------------------------------------*/
 
-/// the playing state of the robot
+/// offensive strategy. The transmitted side is the side on which the robots try to attack
 enum MixedTeamSideEnum {
-	/// robot is not doing anything or incapable of doing anything
-	SIDE_LEFT                                       = 0,
 
-	/// the robot is ready to play or is playing already
-	SIDE_MIDDLE                                     = 1,
+    UNSPECIFIED                                     = 0,
 
-	/// The robot is penalized
-	SIDE_RIGHT                                      = 2,
+	/// attacking on over left side
+	SIDE_LEFT                                       = 1,
+
+	/// attacking through the middle
+	SIDE_MIDDLE                                     = 2,
+
+	/// attacking on the right side
+	SIDE_RIGHT                                      = 3,
 
 };
 
@@ -159,27 +162,31 @@ enum MixedTeamKeyEnum {
 	/// relative position of ball to robot, y-coordinate (in mm)
 	BALL_RELATIVE_Y                              =   MITECOM_RANGE_COGNITION + 5,
 
-	/// relative position of opposing goal to robot, x-coordinate (in mm)
-	OPPGOAL_RELATIVE_X                           =   MITECOM_RANGE_COGNITION + 6,
-
-	/// relative position of opposing goal to robot, y-coordinate (in mm)
-	OPPGOAL_RELATIVE_Y                           =   MITECOM_RANGE_COGNITION + 7,
-
     /// belief of relative position of the ball (0..255), with 0 = no confidence
 	/// and 255 = highest confidence
-	BALL_BELIEF                                  =   MITECOM_RANGE_COGNITION + 8,
+	BALL_BELIEF                                  =   MITECOM_RANGE_COGNITION + 6,
+
+	/// relative position of opposing goal to robot, x-coordinate (in mm)
+	OPPGOAL_RELATIVE_X                           =   MITECOM_RANGE_COGNITION + 7,
+
+	/// relative position of opposing goal to robot, y-coordinate (in mm)
+	OPPGOAL_RELATIVE_Y                           =   MITECOM_RANGE_COGNITION + 8,
 
     /// belief of relative position of the opponent goal (0..255), with 0 = no confidence
 	/// and 255 = highest confidence
-    OPPGOAL_BELIEF                               =   MITECOM_RANGE_COGNITION + 9,
+    OPPGOAL_RELATIVE_BELIEF                               =   MITECOM_RANGE_COGNITION + 9,
 
     // Position of an opponent robot, x-coordinate (in mm)
     // The order is not related to the number of the robot
-    OPPONENT_ROBOT_A_X                             = MITECOM_RANGE_COGNITION + 11,
+    OPPONENT_ROBOT_A_X                             = MITECOM_RANGE_COGNITION + 10,
 
     // Position of an opponent robot, y-coordinate (in mm)
     // The order is not related to the number of the robot
-    OPPONENT_ROBOT_A_Y                             = MITECOM_RANGE_COGNITION + 12,
+    OPPONENT_ROBOT_A_Y                             = MITECOM_RANGE_COGNITION + 11,
+
+    // Belief of accuracy of this robots position, with 0 = no confidence
+	// and 255 = highest confidence
+    OPPONENT_ROBOT_A_BELIEF                        = MITECOM_RANGE_COGNITION + 12,
 
     // Position of an opponent robot, x-coordinate (in mm)
     // The order is not related to the number of the robot
@@ -189,46 +196,69 @@ enum MixedTeamKeyEnum {
     // The order is not related to the number of the robot
     OPPONENT_ROBOT_B_Y                             = MITECOM_RANGE_COGNITION + 14,
 
-    // Position of an opponent robot, x-coordinate (in mm)
-    // The order is not related to the number of the robot
-    OPPONENT_ROBOT_C_X                             = MITECOM_RANGE_COGNITION + 15,
-
-    // Position of an opponent robot, y-coordinate (in mm)
-    // The order is not related to the number of the robot
-    OPPONENT_ROBOT_C_Y                             = MITECOM_RANGE_COGNITION + 16,
+    // Belief of accuracy of this robots position, with 0 = no confidence
+	// and 255 = highest confidence
+    OPPONENT_ROBOT_B_BELIEF                        = MITECOM_RANGE_COGNITION + 15,
 
     // Position of an opponent robot, x-coordinate (in mm)
     // The order is not related to the number of the robot
-    OPPONENT_ROBOT_D_X                             = MITECOM_RANGE_COGNITION + 17,
+    OPPONENT_ROBOT_C_X                             = MITECOM_RANGE_COGNITION + 16,
 
     // Position of an opponent robot, y-coordinate (in mm)
     // The order is not related to the number of the robot
-    OPPONENT_ROBOT_D_Y                             = MITECOM_RANGE_COGNITION + 18,
+    OPPONENT_ROBOT_C_Y                             = MITECOM_RANGE_COGNITION + 17,
+
+    // Belief of accuracy of this robots position, with 0 = no confidence
+	// and 255 = highest confidence
+    OPPONENT_ROBOT_C_BELIEF                        = MITECOM_RANGE_COGNITION + 18,
+
+    // Position of an opponent robot, x-coordinate (in mm)
+    // The order is not related to the number of the robot
+    OPPONENT_ROBOT_D_X                             = MITECOM_RANGE_COGNITION + 19,
+
+    // Position of an opponent robot, y-coordinate (in mm)
+    // The order is not related to the number of the robot
+    OPPONENT_ROBOT_D_Y                             = MITECOM_RANGE_COGNITION + 20,
+
+    // Belief of accuracy of this robots position, with 0 = no confidence
+	// and 255 = highest confidence
+    OPPONENT_ROBOT_D_BELIEF                        = MITECOM_RANGE_COGNITION + 21,
 
     // Position of an teammate, x-coordinate (in mm)
     // The order is not related to the number of the robot
-    TEAM_ROBOT_A_X                                  = MITECOM_RANGE_COGNITION + 19,
+    TEAM_ROBOT_A_X                                 = MITECOM_RANGE_COGNITION + 22,
 
     // Position of an teammate, y-coordinate (in mm)
     // The order is not related to the number of the robot
-    TEAM_ROBOT_A_Y                                  = MITECOM_RANGE_COGNITION + 20,
+    TEAM_ROBOT_A_Y                                 = MITECOM_RANGE_COGNITION + 23,
+
+    // Belief of accuracy of this robots position, with 0 = no confidence
+	// and 255 = highest confidence
+    TEAM_ROBOT_A_BELIEF                            = MITECOM_RANGE_COGNITION + 24,
 
     // Position of an teammate, x-coordinate (in mm)
     // The order is not related to the number of the robot
-    TEAM_ROBOT_B_X                                  = MITECOM_RANGE_COGNITION + 21,
+    TEAM_ROBOT_B_X                                 = MITECOM_RANGE_COGNITION + 25,
 
     // Position of an teammate, y-coordinate (in mm)
     // The order is not related to the number of the robot
-    TEAM_ROBOT_B_Y                                  = MITECOM_RANGE_COGNITION + 22,
+    TEAM_ROBOT_B_Y                                  = MITECOM_RANGE_COGNITION + 26,
+
+    // Belief of accuracy of this robots position, with 0 = no confidence
+	// and 255 = highest confidence
+    TEAM_ROBOT_B_BELIEF                             = MITECOM_RANGE_COGNITION + 27,
 
     // Position of an teammate, x-coordinate (in mm)
     // The order is not related to the number of the robot
-    TEAM_ROBOT_C_X                                  = MITECOM_RANGE_COGNITION + 23,
+    TEAM_ROBOT_C_X                                  = MITECOM_RANGE_COGNITION + 28,
 
     // Position of an teammate, y-coordinate (in mm)
     // The order is not related to the number of the robot
-    TEAM_ROBOT_C_Y                                  = MITECOM_RANGE_COGNITION + 24,
+    TEAM_ROBOT_C_Y                                  = MITECOM_RANGE_COGNITION + 29,
 
+    // Belief of accuracy of this robots position, with 0 = no confidence
+	// and 255 = highest confidence
+    TEAM_ROBOT_C_BELIEF                             = MITECOM_RANGE_COGNITION + 30,
 
 	/* ******************************************************************
 	** ROBOT CAPABILITIES
@@ -248,10 +278,11 @@ enum MixedTeamKeyEnum {
 	** Strategies
 	** *****************************************************************/
 
-	// The attacking direction after the kickoff. The robot which does the kickoff kicks the ball in this direction.
-	// The robot on this side moves forward to accept the pass.b
+	// The attacking direction, for example after the kickoff, the robot which does the kickoff would kick
+	// the ball in this direction. The robot on this side moves forward to accept the pass.
+	// Can be used generally to communicate a basic strategy.
 	// Uses MixedTeamSideEnum
-    KICKOFF_OFFENCE_SIDE                         =  MITECOM_RANGE_STRATEGIES + 1,
+    OFFENSIVE_SIDE                               =  MITECOM_RANGE_STRATEGIES + 1,
 };
 
 typedef MixedTeamKeyEnum MixedTeamKey;

--- a/mitecom-data.h
+++ b/mitecom-data.h
@@ -94,9 +94,29 @@ typedef MixedTeamStateEnum MixedTeamState;
 
 /*------------------------------------------------------------------------------------------------*/
 
+/// the playing state of the robot
+enum MixedTeamSideEnum {
+	/// robot is not doing anything or incapable of doing anything
+	SIDE_LEFT                                       = 0,
+
+	/// the robot is ready to play or is playing already
+	SIDE_MIDDLE                                     = 1,
+
+	/// The robot is penalized
+	SIDE_RIGHT                                      = 2,
+
+};
+
+typedef MixedTeamSideEnum MixedTeamSide;
+
+
+/*------------------------------------------------------------------------------------------------*/
+
+
 static const uint32_t MITECOM_RANGE_STATE        = 0x00000000;
 static const uint32_t MITECOM_RANGE_COGNITION    = 0x00010000;
 static const uint32_t MITECOM_RANGE_CAPABILITIES = 0x00020000;
+static const uint32_t MITECOM_RANGE_STRATEGIES   = 0x00030000;
 static const uint32_t MITECOM_RANGE_USERDEFINED  = 0x10000000; // individual settings
 
 /// enum for addressing the different values the team shares
@@ -145,6 +165,70 @@ enum MixedTeamKeyEnum {
 	/// relative position of opposing goal to robot, y-coordinate (in mm)
 	OPPGOAL_RELATIVE_Y                           =   MITECOM_RANGE_COGNITION + 7,
 
+    /// belief of relative position of the ball (0..255), with 0 = no confidence
+	/// and 255 = highest confidence
+	BALL_BELIEF                                  =   MITECOM_RANGE_COGNITION + 8,
+
+    /// belief of relative position of the opponent goal (0..255), with 0 = no confidence
+	/// and 255 = highest confidence
+    OPPGOAL_BELIEF                               =   MITECOM_RANGE_COGNITION + 9,
+
+    // Position of an opponent robot, x-coordinate (in mm)
+    // The order is not related to the number of the robot
+    OPPONENT_ROBOT_A_X                             = MITECOM_RANGE_COGNITION + 11,
+
+    // Position of an opponent robot, y-coordinate (in mm)
+    // The order is not related to the number of the robot
+    OPPONENT_ROBOT_A_Y                             = MITECOM_RANGE_COGNITION + 12,
+
+    // Position of an opponent robot, x-coordinate (in mm)
+    // The order is not related to the number of the robot
+    OPPONENT_ROBOT_B_X                             = MITECOM_RANGE_COGNITION + 13,
+
+    // Position of an opponent robot, y-coordinate (in mm)
+    // The order is not related to the number of the robot
+    OPPONENT_ROBOT_B_Y                             = MITECOM_RANGE_COGNITION + 14,
+
+    // Position of an opponent robot, x-coordinate (in mm)
+    // The order is not related to the number of the robot
+    OPPONENT_ROBOT_C_X                             = MITECOM_RANGE_COGNITION + 15,
+
+    // Position of an opponent robot, y-coordinate (in mm)
+    // The order is not related to the number of the robot
+    OPPONENT_ROBOT_C_Y                             = MITECOM_RANGE_COGNITION + 16,
+
+    // Position of an opponent robot, x-coordinate (in mm)
+    // The order is not related to the number of the robot
+    OPPONENT_ROBOT_D_X                             = MITECOM_RANGE_COGNITION + 17,
+
+    // Position of an opponent robot, y-coordinate (in mm)
+    // The order is not related to the number of the robot
+    OPPONENT_ROBOT_D_Y                             = MITECOM_RANGE_COGNITION + 18,
+
+    // Position of an teammate, x-coordinate (in mm)
+    // The order is not related to the number of the robot
+    TEAM_ROBOT_A_X                                  = MITECOM_RANGE_COGNITION + 19,
+
+    // Position of an teammate, y-coordinate (in mm)
+    // The order is not related to the number of the robot
+    TEAM_ROBOT_A_Y                                  = MITECOM_RANGE_COGNITION + 20,
+
+    // Position of an teammate, x-coordinate (in mm)
+    // The order is not related to the number of the robot
+    TEAM_ROBOT_B_X                                  = MITECOM_RANGE_COGNITION + 21,
+
+    // Position of an teammate, y-coordinate (in mm)
+    // The order is not related to the number of the robot
+    TEAM_ROBOT_B_Y                                  = MITECOM_RANGE_COGNITION + 22,
+
+    // Position of an teammate, x-coordinate (in mm)
+    // The order is not related to the number of the robot
+    TEAM_ROBOT_C_X                                  = MITECOM_RANGE_COGNITION + 23,
+
+    // Position of an teammate, y-coordinate (in mm)
+    // The order is not related to the number of the robot
+    TEAM_ROBOT_C_Y                                  = MITECOM_RANGE_COGNITION + 24,
+
 
 	/* ******************************************************************
 	** ROBOT CAPABILITIES
@@ -159,6 +243,15 @@ enum MixedTeamKeyEnum {
 
 	/// the maximum (realistic) distance the ball can be kicked
 	ROBOT_MAX_KICKING_DISTANCE                   =  MITECOM_RANGE_CAPABILITIES + 3,
+
+    /* ******************************************************************
+	** Strategies
+	** *****************************************************************/
+
+	// The attacking direction after the kickoff. The robot which does the kickoff kicks the ball in this direction.
+	// The robot on this side moves forward to accept the pass.b
+	// Uses MixedTeamSideEnum
+    KICKOFF_OFFENCE_SIDE                         =  MITECOM_RANGE_STRATEGIES + 1,
 };
 
 typedef MixedTeamKeyEnum MixedTeamKey;


### PR DESCRIPTION
Hi,

I am currently working with the mitecom and I saw that there was no possibility to share robot positions with the team mates, so I added it.
I also added a section for communication about strategies, for example the attacking direction after a kick off. Furthermore, I added a belief value for the ball and goal information.
For the moment, I just changed this in the mitecom_data.h as I wanted to make sure, that this finds your approval. If you like it, I will implement it fully.
I also did a small update on the documentation about the orientation, please check if I did explain it right.